### PR TITLE
Update Module.php for compatibility with ZF2 2.0.3

### DIFF
--- a/src/SwaggerModule/Module.php
+++ b/src/SwaggerModule/Module.php
@@ -22,8 +22,8 @@ namespace SwaggerModule;
 
 class Module
 {
-    
-    public function getServiceConfiguration()
+
+    public function getServiceConfig()
     {
         return array(
             'aliases' => array(
@@ -34,5 +34,5 @@ class Module
             )
         );
     }
-    
+
 }


### PR DESCRIPTION
getServiceConfiguration() became getServiceConfig() at some point during the release candidates, this PR just addresses this change
