### PR TITLE
Added ViewJsonStrategy to fix rendering errors

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -32,10 +32,10 @@ return array(
             'SwaggerModule\Controller\Documentation' => 'SwaggerModule\Controller\DocumentationController'
         )
     ),
-	
-	'view_manager' => array( 
-        'strategies' => array( 
-            'ViewJsonStrategy' 
-        ), 
+
+    'view_manager' => array(
+        'strategies' => array(
+            'ViewJsonStrategy'
+        ),
     ),
 );


### PR DESCRIPTION
This will prevent the default api document route supplied in the same file (/api/docs) from resulting in an error when using the Zend Framework 2.2.x skeleton application, by enabling the JSON view strategy.
