### PR TITLE
Added resource details options for configure Swagger->getResource

### DIFF
--- a/config/swagger.global.php.dist
+++ b/config/swagger.global.php.dist
@@ -8,5 +8,13 @@ return array(
         'paths' => array(
             __DIR__ . '/../../module/Application/src/Application/Controller',
         ),
+
+        'resource_options' => array(
+            'output' => 'array',
+            'json_pretty_print' => true, // for outputtype 'json'
+            'defaultBasePath' => null,
+            'defaultApiVersion' => null,
+            'defaultSwaggerVersion' => '1.2',
+        ),
     )
 );

--- a/src/SwaggerModule/Controller/DocumentationController.php
+++ b/src/SwaggerModule/Controller/DocumentationController.php
@@ -50,7 +50,11 @@ class DocumentationController extends AbstractActionController
     {
         /** @var $swagger \Swagger\Swagger */
         $swagger = $this->serviceLocator->get('Swagger\Swagger');
-        $resource = $swagger->getResource('/' . $this->params('resource', null));
+
+        /** @var $options \SwaggerModule\Options\ModuleOptions */
+        $options = $this->serviceLocator->get('SwaggerModule\Options\ModuleOptions');
+        $resourceOptions = $options->getResourceOptions() ? : array();
+        $resource = $swagger->getResource('/' . $this->params('resource', null), $resourceOptions);
 
         if ($resource === false) {
             return new JsonModel();

--- a/src/SwaggerModule/Options/ModuleOptions.php
+++ b/src/SwaggerModule/Options/ModuleOptions.php
@@ -35,6 +35,12 @@ class ModuleOptions extends AbstractOptions
      */
     protected $paths;
 
+    /**
+     * Key - Value array for resource details 
+     *
+     * @var array 
+     */
+    protected $resourceOptions;
 
     /**
      * Set an array of paths where the files to be scanned by Swagger are searched
@@ -94,5 +100,23 @@ class ModuleOptions extends AbstractOptions
         }
 
         return $fileList;
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function getResourceOptions()
+    {
+        return $this->resourceOptions;
+    }
+
+    /**
+     *
+     * @param array $resourceOptions
+     */
+    public function setResourceOptions($resourceOptions)
+    {
+        $this->resourceOptions = $resourceOptions;
     }
 }


### PR DESCRIPTION
This will give options to further configure the behavior for swagger library. I made this mostly because i would want to edit the `defaultBasePath` instead of hard coding the basePath in each `@SWG\Resource`. The defaults is taken from `Swagger\Swagger::getResource`
