### PR TITLE
BC for ZF2, solves #12

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -29,7 +29,7 @@ return array(
 
     'controllers' => array(
         'factories' => array(
-            'SwaggerModule\Controller\Documentation' => 'SwaggerModule\Controller\DocumentationControllerFactory',
+            'SwaggerModule\Controller\Documentation' => 'SwaggerModule\Controller\DocumentationControllerZf2ShimFactory',
         ),
     ),
 

--- a/src/SwaggerModule/Controller/DocumentationControllerZf2ShimFactory.php
+++ b/src/SwaggerModule/Controller/DocumentationControllerZf2ShimFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * SwaggerModule
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @copyright  Copyright (c) 2012 OuterEdge UK Ltd (http://www.outeredgeuk.com)
+ * @license http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+namespace SwaggerModule\Controller;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * DocumentationController factory
+ *
+ * @deprecated ZF2 BC, see \Zend\ServiceManager\FactoryInterface
+ */
+class DocumentationControllerZf2ShimFactory implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        // zf2 fallback, get real service locator
+        if (get_class($serviceLocator) === 'Zend\Mvc\Controller\ControllerManager') {
+            $serviceLocator = $serviceLocator->getServiceLocator();
+        }
+
+        $controller = new DocumentationController();
+        /** @var $swagger \Swagger\Annotations\Swagger */
+        $swagger = $serviceLocator->get('Swagger\Annotations\Swagger');
+        $controller->setSwagger($swagger);
+        return $controller;
+    }
+}

--- a/src/SwaggerModule/Controller/DocumentationControllerZf2ShimFactory.php
+++ b/src/SwaggerModule/Controller/DocumentationControllerZf2ShimFactory.php
@@ -32,14 +32,12 @@ class DocumentationControllerZf2ShimFactory implements FactoryInterface
 {
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        // zf2 fallback, get real service locator
-        if (get_class($serviceLocator) === 'Zend\Mvc\Controller\ControllerManager') {
-            $serviceLocator = $serviceLocator->getServiceLocator();
-        }
+        /** @var $realServiceLocator ServiceLocatorInterface */
+        $realServiceLocator = $serviceLocator->getServiceLocator();
 
         $controller = new DocumentationController();
         /** @var $swagger \Swagger\Annotations\Swagger */
-        $swagger = $serviceLocator->get('Swagger\Annotations\Swagger');
+        $swagger = $realServiceLocator->get('Swagger\Annotations\Swagger');
         $controller->setSwagger($swagger);
         return $controller;
     }


### PR DESCRIPTION
Please test with ZF 3.x.

I have tested with ZF 2.3.1, where:
- `$serviceLocator` is `Zend\Mvc\Controller\ControllerManager`
- `Zend\Mvc\Controller\ControllerManager` does not have access to real service locator by calling `get('service_name')` and calling `$serviceLocator->getServiceLocator();` breaks `ServiceLocatorInterface`, but works.