### PR TITLE
'Zend\ServiceManager\Exception\ServiceNotFoundException'

### DIFF
--- a/src/SwaggerModule/Controller/DocumentationControllerFactory.php
+++ b/src/SwaggerModule/Controller/DocumentationControllerFactory.php
@@ -36,11 +36,11 @@ class DocumentationControllerFactory implements AbstractFactoryInterface
         return $this->canCreate($services, $requestedName);
     }
 
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName)
     {
         $controller = new DocumentationController();
         /** @var \Swagger\Annotations\Swagger */
-        $swagger = $container->get('Swagger\Annotations\Swagger');
+        $swagger = $container->getServiceLocator()->get('Swagger\Annotations\Swagger');
         $controller->setSwagger($swagger);
         return $controller;
     }


### PR DESCRIPTION
These changes fix a problem that the swagger object was requested from the ControllerManager, but was registered in the ServiceLocator and thus not beeing found.

I've also removed an unused parameter from the __invoke method that caused a warning.