### PR TITLE
Update documentation controller factory to match factory interface signature

### DIFF
--- a/src/SwaggerModule/Controller/DocumentationControllerFactory.php
+++ b/src/SwaggerModule/Controller/DocumentationControllerFactory.php
@@ -21,7 +21,9 @@
 namespace SwaggerModule\Controller;
 
 use Interop\Container\ContainerInterface;
+use Swagger\Annotations\Swagger;
 use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DocumentationControllerFactory implements AbstractFactoryInterface
@@ -36,17 +38,20 @@ class DocumentationControllerFactory implements AbstractFactoryInterface
         return $this->canCreate($services, $requestedName);
     }
 
-    public function __invoke(ContainerInterface $container, $requestedName)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $controller = new DocumentationController();
-        /** @var \Swagger\Annotations\Swagger */
-        $swagger = $container->getServiceLocator()->get('Swagger\Annotations\Swagger');
+        /** @var Swagger $swagger */
+        $swagger = $container->get('Swagger\Annotations\Swagger');
         $controller->setSwagger($swagger);
         return $controller;
     }
 
     public function createServiceWithName(ServiceLocatorInterface $services, $name, $requestedName)
     {
+        if ($services instanceof AbstractPluginManager) {
+            $services = $services->getServiceLocator();
+        }
         return $this($services, $requestedName);
     }
 }


### PR DESCRIPTION
PHP 7.3 had backward incompatible change that no longer allows optional parameters to be omitted by method implementations or overrides
This fixes #15 

zend-servicemanager 3.0 release changed plugin managers to pass main container to factories.
To avoid unnecessarily triggering deprecation errors I moved the `getServiceLocator()` call from `__invoke()` used by SM v3 to the `createServiceWithName()` method used by SM v2.
